### PR TITLE
Fix h1,h2,h3,h4 font-size in markdown docs

### DIFF
--- a/static/css/markdown.css
+++ b/static/css/markdown.css
@@ -28,6 +28,21 @@
 .markdown h4,.markdown h5,.markdown h6 {
     font-weight: bolder
 }
+.markdown h1 {
+    font-size: 3em
+}
+
+.markdown h2 {
+    font-size: 2em
+}
+
+.markdown h3 {
+    font-size: 1.5em
+}
+
+.markdown h4 {
+    font-size: 1em
+}
 
 .markdown h5 {
     font-size: .875em


### PR DESCRIPTION
Make markdown documentations more readable.